### PR TITLE
Set curl HTTP version to 1.1

### DIFF
--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -24,6 +24,7 @@ class Podio {
     self::$headers = array(
       'Accept' => 'application/json',
     );
+    curl_setopt(self::$ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
     curl_setopt(self::$ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt(self::$ch, CURLOPT_SSL_VERIFYPEER, 1);
     curl_setopt(self::$ch, CURLOPT_SSL_VERIFYHOST, 2);


### PR DESCRIPTION
The PHP 7.4 image uses a newer cURL version which by default uses HTTP 2, but that doesn't work with the podio-php library.