### PR TITLE
Prevent array access on null

### DIFF
--- a/lib/PodioError.php
+++ b/lib/PodioError.php
@@ -8,7 +8,7 @@ class PodioError extends Exception {
     $this->body = json_decode($body, TRUE);
     $this->status = $status;
     $this->url = $url;
-    $this->request = $this->body['request'];
+    $this->request = isset($this->body['request']) ? $this->body['request'] : array();
     parent::__construct(get_class($this), 1, null);
   }
 
@@ -17,7 +17,9 @@ class PodioError extends Exception {
     if (!empty($this->body['error_description'])) {
       $str .= ': "'.$this->body['error_description'].'"';
     }
-    $str .= "\nRequest URL: ".$this->request['url'];
+    if (!empty($this->request['url'])) {
+      $str .= "\nRequest URL: ".$this->request['url'];
+    }
     if (!empty($this->request['query_string'])) {
       $str .= '?'.$this->request['query_string'];
     }


### PR DESCRIPTION
Fixes these notices:
https://app.datadoghq.com/logs?cols=core_host%2Ccore_service%2Clog_level_name&event=AQAAAXRJALfis2kZZAAAAABBWFJKQUwtWDVnS1VSNjZsLXNBQQ&from_ts=1598951763228&index=main&live=true&messageDisplay=inline&query=service%3Aphp+-status%3Ainfo++name%3A%28nodes.prod-2020.k8s.local+OR+platform-nodes.prod.k8s.local+OR+cron-nodes.prod-2020.k8s.local%29&saved_view=59039&stream_sort=desc&to_ts=1598955363228