### PR TITLE
Fix Podio file upload

### DIFF
--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -147,7 +147,10 @@ class Podio {
     }
 
     // Reset attributes so we can reuse curl object
-    curl_setopt(self::$ch, CURLOPT_POSTFIELDS, null);
+    if (self::POST !== $method) {
+      curl_setopt(self::$ch, CURLOPT_POSTFIELDS, null);
+    }
+
     unset(self::$headers['Content-length']);
     $original_url = $url;
     $encoded_attributes = null;


### PR DESCRIPTION
When GL was migrated on the new cluster the Podio upload file didn't wok anymore, that is caused by the reset than is done on curl opt CURLOPT_POSTFIELDS, internally curl opt are overridden so in case of POST this is always overridden so there is no need for reset